### PR TITLE
Letting send silent pushes

### DIFF
--- a/src/sendAPN.js
+++ b/src/sendAPN.js
@@ -10,7 +10,6 @@ module.exports = (regIds, data, settings) => {
         encoding: data.encoding,
         payload: data.custom || {},
         badge: data.badge,
-        sound: data.sound || 'ping.aiff',
         alert: data.alert || {
             title: data.title,
             body: data.body,
@@ -30,6 +29,9 @@ module.exports = (regIds, data, settings) => {
         collapseId: data.collapseKey,
         mutableContent: data.mutableContent || 0,
     });
+    if (data.sound) {
+        message.sound = data.sound;   
+    }
     const connection = new apn.Provider(settings.apn);
 
     return connection.send(message, regIds)


### PR DESCRIPTION
I'm not able to test GCM but APNS. So, I would like to allow sending silent pushes for APNS.  Because APNS (or iOS itself) sets default push sound if the `sound` property defined. Even you set an empty string or non-existing sound in the payload for the purpose of sending silent push.